### PR TITLE
Add dummy package for Linux and Darwin

### DIFF
--- a/sequence_dummy.go
+++ b/sequence_dummy.go
@@ -1,0 +1,11 @@
+// +build linux darwin
+
+package sequences
+
+import (
+	"fmt"
+)
+
+func EnableVirtualTerminalProcessing() error {
+	return fmt.Errorf("windows only package")
+}


### PR DESCRIPTION
Add an empty sequences package to allow getting it from a linux or darwin system like travis worker VM.
It allows cross compiling this package (or dependents) on non windows systems

Fix for: 
``` bash
$ go get github.com/konsorten/go-windows-terminal-sequences
package github.com/konsorten/go-windows-terminal-sequences: no buildable Go source files in /home/travis/gopath/src/github.com/konsorten/go-windows-terminal-sequences
```